### PR TITLE
[#36] Implementing product list feature

### DIFF
--- a/src/main/java/com/aebong/store/controller/api/ProductController.java
+++ b/src/main/java/com/aebong/store/controller/api/ProductController.java
@@ -31,8 +31,11 @@ public class ProductController {
     }
 
     @PostMapping("/paging")
-    public ResponseEntity<ApiResponse<Page<ProductGetInfo>>> getProducts() {
-        Pageable pageable = PageRequest.of(0,20);
+    public ResponseEntity<ApiResponse<Page<ProductGetInfo>>> getProducts(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
         return new ResponseEntity<>(ApiResponse.success(productService.getProducts(pageable)), HttpStatus.OK);
     }
 

--- a/src/main/java/com/aebong/store/controller/view/ProductViewController.java
+++ b/src/main/java/com/aebong/store/controller/view/ProductViewController.java
@@ -32,4 +32,9 @@ public class ProductViewController {
         return "products/product-get";
     }
 
+    @GetMapping("/list")
+    public String getProducts(Model model) {
+        return "products/product-list";
+    }
+
 }

--- a/src/main/resources/static/js/products/product-list.js
+++ b/src/main/resources/static/js/products/product-list.js
@@ -1,0 +1,188 @@
+$(document).ready(function () {
+    let currentPage = 0;
+    let pageSize = 20;
+    let totalPages = 0;
+
+    loadProducts();
+
+    $("#btnReload").on("click", function () {
+        loadProducts();
+    });
+
+    $("#pageSize").on("change", function () {
+        pageSize = Number($(this).val()) || 20;
+        currentPage = 0;
+        loadProducts();
+    });
+
+    function loadProducts() {
+        showError(null);
+        setLoading();
+
+        $.ajax({
+            type: "POST",
+            url: `/api/v1/products/paging?page=${currentPage}&size=${pageSize}`,
+            contentType: "application/json; charset=utf-8",
+            success: function (response) {
+                if (response.code !== "SUCCESS" || !response.data) {
+                    showError(response.message || "상품 목록 조회 응답이 올바르지 않습니다.");
+                    setEmpty("조회 결과가 없습니다.");
+                    return;
+                }
+
+                currentPage = Number(response.data.number || 0);
+                totalPages = Number(response.data.totalPages || 0);
+                renderTable(response.data.content || [], currentPage, Number(response.data.size || pageSize));
+                renderPagination(currentPage, totalPages);
+                setText("#totalCount", response.data.totalElements || 0);
+            },
+            error: function (jqXHR) {
+                let message = "상품 목록 조회 중 오류가 발생했습니다.";
+                try {
+                    const errorResponse = JSON.parse(jqXHR.responseText);
+                    if (errorResponse && errorResponse.message) {
+                        message = errorResponse.message;
+                    }
+                } catch (e) {
+                    // ignore parse error
+                }
+
+                showError(message);
+                setEmpty("조회 결과가 없습니다.");
+            }
+        });
+    }
+
+    function setLoading() {
+        const row = '<tr><td colspan="8" class="table-empty">데이터를 불러오는 중입니다.</td></tr>';
+        $("#productTableBody").html(row);
+    }
+
+    function setEmpty(message) {
+        const row = `<tr><td colspan="8" class="table-empty">${escapeHtml(message)}</td></tr>`;
+        $("#productTableBody").html(row);
+        $("#pagination").empty();
+        setText("#totalCount", "0");
+    }
+
+    function renderTable(products, page, size) {
+        if (products.length === 0) {
+            setEmpty("등록된 상품이 없습니다.");
+            return;
+        }
+
+        const rows = products.map(function (product, index) {
+            const price = resolveSalesAmount(product);
+            const productId = valueOrDash(product.productId);
+            const rowNumber = page * size + index + 1;
+            return `
+                <tr class="clickable" data-product-id="${productId}">
+                    <td class="text-center">${rowNumber}</td>
+                    <td class="product-code">${valueOrDash(product.productCode)}</td>
+                    <td>${valueOrDash(product.productName)}</td>
+                    <td>${valueOrDash(product.productType)}</td>
+                    <td>${valueOrDash(product.manufacturerCountry)}</td>
+                    <td>${valueOrDash(product.releaseDatetime)}</td>
+                    <td class="text-end">${formatNumber(price)}원</td>
+                    <td class="text-center">
+                        <a href="/products/info/${encodeURIComponent(productId)}" class="btn btn-sm btn-outline-dark">상세보기</a>
+                    </td>
+                </tr>
+            `;
+        }).join("");
+
+        $("#productTableBody").html(rows);
+
+        $("#productTableBody tr").on("click", function (event) {
+            if ($(event.target).closest("a").length > 0) {
+                return;
+            }
+            const productId = $(this).data("product-id");
+            if (productId) {
+                window.location.href = `/products/info/${encodeURIComponent(productId)}`;
+            }
+        });
+    }
+
+    function renderPagination(page, total) {
+        const $pagination = $("#pagination");
+        $pagination.empty();
+
+        if (total <= 0) {
+            return;
+        }
+
+        $pagination.append(createPageItem("이전", page - 1, page <= 0, false));
+
+        let startPage = Math.max(0, page - 2);
+        let endPage = Math.min(total - 1, startPage + 4);
+        startPage = Math.max(0, endPage - 4);
+
+        for (let i = startPage; i <= endPage; i += 1) {
+            $pagination.append(createPageItem(String(i + 1), i, false, i === page));
+        }
+
+        $pagination.append(createPageItem("다음", page + 1, page >= total - 1, false));
+
+        $pagination.find("a[data-page]").on("click", function (event) {
+            event.preventDefault();
+            const targetPage = Number($(this).data("page"));
+            if (Number.isNaN(targetPage) || targetPage === currentPage) {
+                return;
+            }
+            currentPage = targetPage;
+            loadProducts();
+        });
+    }
+
+    function createPageItem(label, page, disabled, active) {
+        const disabledClass = disabled ? " disabled" : "";
+        const activeClass = active ? " active" : "";
+        return `
+            <li class="page-item${disabledClass}${activeClass}">
+                <a class="page-link" href="#" data-page="${page}">${label}</a>
+            </li>
+        `;
+    }
+
+    function resolveSalesAmount(product) {
+        if (!product.priceList || product.priceList.length === 0) {
+            return 0;
+        }
+        return product.priceList[0].salesAmount || 0;
+    }
+
+    function formatNumber(value) {
+        const numberValue = Number(value || 0);
+        return numberValue.toLocaleString("ko-KR");
+    }
+
+    function valueOrDash(value) {
+        if (value === null || value === undefined || value === "") {
+            return "-";
+        }
+        return value;
+    }
+
+    function setText(selector, value) {
+        $(selector).text(valueOrDash(value));
+    }
+
+    function showError(message) {
+        const $box = $("#errorBox");
+        if (!message) {
+            $box.addClass("d-none").text("");
+            return;
+        }
+        $box.removeClass("d-none").text(message);
+    }
+
+    function escapeHtml(text) {
+        return String(text)
+            .replaceAll("&", "&amp;")
+            .replaceAll("<", "&lt;")
+            .replaceAll(">", "&gt;")
+            .replaceAll('"', "&quot;")
+            .replaceAll("'", "&#039;");
+    }
+});

--- a/src/main/resources/templates/fragment/admin/nav-side.html
+++ b/src/main/resources/templates/fragment/admin/nav-side.html
@@ -19,7 +19,7 @@
             <div class="collapse" id="collapseLayouts" aria-labelledby="headingOne" data-bs-parent="#sidenavAccordion">
                 <nav class="sb-sidenav-menu-nested nav">
                     <a class="nav-link" href="/products/register">상품등록</a>
-                    <a class="nav-link" href="#">상품목록</a>
+                    <a class="nav-link" href="/products/list">상품목록</a>
                 </nav>
             </div>
             <a class="nav-link collapsed" href="#" data-bs-toggle="collapse" data-bs-target="#collapsePages" aria-expanded="false" aria-controls="collapsePages">

--- a/src/main/resources/templates/products/product-get.html
+++ b/src/main/resources/templates/products/product-get.html
@@ -55,7 +55,8 @@
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h2 class="form-title mb-0">상품 정보</h2>
             <div>
-                <a th:href="@{/products}" class="btn btn-outline-secondary">목록</a>
+                <a th:href="@{/products/modify}" class="btn btn-secondary">수정</a>
+                <a th:href="@{/products/list}" class="btn btn-outline-secondary">목록</a>
             </div>
         </div>
 
@@ -120,7 +121,7 @@
                     <table class="table table-hover mb-0">
                         <thead>
                         <tr>
-                            <th class="text-center" style="width: 50px;">#</th>
+                            <th class="text-center" style="width: 50px;">No</th>
                             <th>적용 시작일</th>
                             <th>적용 종료일</th>
                             <th class="text-end">판매가</th>

--- a/src/main/resources/templates/products/product-list.html
+++ b/src/main/resources/templates/products/product-list.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="ko"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/layout-admin}">
+<head>
+    <meta charset="UTF-8">
+    <title>상품 목록</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <th:block layout:fragment="css">
+        <style>
+            .form-title {
+                margin-bottom: 1.5rem;
+                font-size: 1.5rem;
+                font-weight: 700;
+            }
+
+            .product-table thead th {
+                background-color: #f8f9fa;
+                font-weight: 600;
+                white-space: nowrap;
+            }
+
+            .product-table tbody td {
+                vertical-align: middle;
+            }
+
+            .product-code {
+                font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+                font-size: 0.875rem;
+            }
+
+            .table-empty {
+                color: #6c757d;
+                text-align: center;
+                padding: 2rem 0;
+            }
+
+            .clickable {
+                cursor: pointer;
+            }
+
+            .page-size-select {
+                width: auto;
+                min-width: 110px;
+            }
+
+            .pagination-wrap {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 1rem;
+                padding: 1rem;
+                border-top: 1px solid #ececec;
+                background-color: #fff;
+            }
+
+            .pagination {
+                margin: 0;
+            }
+
+            .pagination .page-item.active .page-link {
+                background-color: #000000;
+                border-color: #000000;
+                color: #ffffff;
+            }
+
+        </style>
+    </th:block>
+</head>
+
+<div layout:fragment="content">
+    <div class="container-fluid px-5 py-4">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h2 class="form-title mb-0">상품 목록</h2>
+            <a th:href="@{/products/register}" class="btn btn-dark">상품 등록</a>
+        </div>
+
+        <div class="alert alert-danger d-none" id="errorBox"></div>
+
+        <div class="card shadow-sm">
+            <div class="card-header bg-secondary text-white fw-semibold d-flex justify-content-between align-items-center">
+                <span>조회 결과 (<span id="totalCount">0</span>건)</span>
+                <button type="button" class="btn btn-sm btn-light" id="btnReload">새로고침</button>
+            </div>
+            <div class="card-body bg-white p-0">
+                <div class="table-responsive">
+                    <table class="table table-hover mb-0 product-table">
+                        <thead>
+                        <tr>
+                            <th class="text-center" style="width: 70px;">No</th>
+                            <th style="width: 160px;">상품코드</th>
+                            <th>상품명</th>
+                            <th style="width: 130px;">상품유형</th>
+                            <th style="width: 180px;">제조국</th>
+                            <th style="width: 180px;">출시일시</th>
+                            <th class="text-end" style="width: 130px;">판매가</th>
+                            <th class="text-center" style="width: 120px;">상세</th>
+                        </tr>
+                        </thead>
+                        <tbody id="productTableBody">
+                        <tr>
+                            <td colspan="8" class="table-empty">데이터를 불러오는 중입니다.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="pagination-wrap">
+                <div class="d-flex align-items-center gap-2">
+                    <label for="pageSize" class="form-label mb-0 text-muted">페이지 크기</label>
+                    <select id="pageSize" class="form-select form-select-sm page-size-select">
+                        <option value="20" selected>20개</option>
+                        <option value="50">50개</option>
+                        <option value="100">100개</option>
+                    </select>
+                </div>
+                <nav aria-label="상품 목록 페이징">
+                    <ul class="pagination" id="pagination"></ul>
+                </nav>
+            </div>
+        </div>
+    </div>
+</div>
+
+<th:block layout:fragment="script">
+    <script th:src="@{/js/products/product-list.js}"></script>
+</th:block>
+</html>


### PR DESCRIPTION
## 목적
- #36 이슈의 남은 작업인 `product get list view & event` 구현을 완료합니다.
- 상품 목록 화면의 사용성을 높이기 위해 일반적인 페이지네이션 UI를 적용합니다.
- 상품 상세 화면 상단 액션(수정/목록) UX를 보완합니다.

## 주요 변경 사항

### 1) Product 목록 View/Event 구현
- `products/product-list.html` 신규 구현
  - 어드민 테마 유지
  - 상품 목록 테이블 렌더링 영역 구성
  - 새로고침 버튼, 오류 표시 영역 추가
- `static/js/products/product-list.js` 신규 구현
  - `POST /api/v1/products/paging` 호출
  - 응답 데이터(`Page<ProductGetInfo>`) 기반 목록 렌더링
  - 행 클릭/상세 버튼 클릭 시 `/products/info/{productId}` 이동
  - 오류/빈 데이터 상태 처리

### 2) 페이지네이션 UX 개선
- 카드형 페이지 상태 뷰 제거
- 일반 페이지네이션 적용
  - `이전/다음` 1페이지 단위 이동
  - 페이지 번호 최대 5개 표시
- 페이지 크기 드롭다운 추가
  - `20 / 50 / 100` 개
- Active 페이지 스타일 적용
  - `.pagination .page-item.active .page-link` 색상 `#000000`

### 3) 페이징 API 파라미터 처리 보강
- `ProductController#getProducts` 개선
  - `page`, `size` request param 수용
  - `PageRequest.of(page, size)`로 동적 조회

### 4) Product 상세 화면 액션 보완
- `products/product-get.html`
  - 상단 `목록` 버튼 왼쪽에 `수정` 버튼 추가
  - 회색 계열(`btn-secondary`) 스타일 적용

## 변경 파일
- `src/main/java/com/aebong/store/controller/api/ProductController.java`
- `src/main/resources/templates/products/product-list.html`
- `src/main/resources/static/js/products/product-list.js`
- `src/main/resources/templates/products/product-get.html`

## 테스트
- `./gradlew test --tests "com.aebong.store.controller.ProductControllerTest"`
- 결과: **BUILD SUCCESSFUL**

## 영향도
- Product 목록 조회 화면 및 상세 화면 상단 액션 UI에 영향
- Product 목록 API는 기존 고정 페이징(0,20)에서 요청 파라미터 기반 페이징으로 확장됨
- 기존 기본 동작은 `page=0`, `size=20` 기본값으로 유지됨
