### PR TITLE
[Phase 1] Spring Security JWT + Auth API + 배송지 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,12 +44,24 @@ dependencies {
 
 	implementation 'org.apache.commons:commons-lang3:3.18.0'
 
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// JWT (JJWT 0.12.x)
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	// WebFlux (Toss Payments WebClient)
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:3.0.2'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 ext {

--- a/src/main/java/com/aebong/store/common/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/aebong/store/common/api/GlobalExceptionHandler.java
@@ -1,5 +1,8 @@
 package com.aebong.store.common.api;
 
+import com.aebong.store.common.exception.ForbiddenException;
+import com.aebong.store.common.exception.ResourceNotFoundException;
+import com.aebong.store.common.exception.UnauthorizedException;
 import com.aebong.store.common.enums.CustomErrorType;
 import com.aebong.store.common.exceptions.ProductApplicationException;
 import com.aebong.store.common.exceptions.UserApplicationException;
@@ -27,6 +30,30 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(e.getErrorType().getStatus())
                 .body(ApiResponse.error(e.getErrorType().name(), e.getErrorType().getMessageKr()));
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<?> handleException(UnauthorizedException e) {
+        log.error(">>>>> [UnauthorizedException] ERROR: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(ApiResponse.error("UNAUTHORIZED", e.getMessage()));
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<?> handleException(ForbiddenException e) {
+        log.error(">>>>> [ForbiddenException] ERROR: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(ApiResponse.error("FORBIDDEN", e.getMessage()));
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<?> handleException(ResourceNotFoundException e) {
+        log.error(">>>>> [ResourceNotFoundException] ERROR: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error("NOT_FOUND", e.getMessage()));
     }
 
     @ExceptionHandler(RuntimeException.class)

--- a/src/main/java/com/aebong/store/common/enums/user/UserRole.java
+++ b/src/main/java/com/aebong/store/common/enums/user/UserRole.java
@@ -1,0 +1,15 @@
+package com.aebong.store.common.enums.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserRole {
+
+    ADMIN("ROLE_ADMIN"),
+    CUSTOMER("ROLE_CUSTOMER");
+
+    private final String role;
+
+}

--- a/src/main/java/com/aebong/store/common/exception/ForbiddenException.java
+++ b/src/main/java/com/aebong/store/common/exception/ForbiddenException.java
@@ -1,0 +1,8 @@
+package com.aebong.store.common.exception;
+
+public class ForbiddenException extends RuntimeException {
+
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/aebong/store/common/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/aebong/store/common/exception/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package com.aebong.store.common.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/aebong/store/common/exception/UnauthorizedException.java
+++ b/src/main/java/com/aebong/store/common/exception/UnauthorizedException.java
@@ -1,0 +1,8 @@
+package com.aebong.store.common.exception;
+
+public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/aebong/store/common/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/aebong/store/common/security/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,34 @@
+package com.aebong.store.common.security.jwt;
+
+import com.aebong.store.common.api.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        String body = objectMapper.writeValueAsString(
+                ApiResponse.error("FORBIDDEN", "접근 권한이 없습니다."));
+        response.getWriter().write(body);
+    }
+
+}

--- a/src/main/java/com/aebong/store/common/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/aebong/store/common/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package com.aebong.store.common.security.jwt;
+
+import com.aebong.store.common.api.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        String body = objectMapper.writeValueAsString(
+                ApiResponse.error("UNAUTHORIZED", "인증이 필요합니다."));
+        response.getWriter().write(body);
+    }
+
+}

--- a/src/main/java/com/aebong/store/common/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/aebong/store/common/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package com.aebong.store.common.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/aebong/store/common/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/aebong/store/common/security/jwt/JwtAuthenticationFilter.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -21,6 +23,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final String BEARER_PREFIX = "Bearer ";
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -29,7 +32,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = resolveToken(request);
 
         if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
-            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(jwtTokenProvider.getSubject(token));
+            Authentication authentication = jwtTokenProvider.getAuthentication(token, userDetails);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 

--- a/src/main/java/com/aebong/store/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/aebong/store/common/security/jwt/JwtTokenProvider.java
@@ -8,15 +8,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -64,15 +62,8 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public Authentication getAuthentication(String token) {
-        Claims claims = parseClaims(token);
-        Collection<? extends GrantedAuthority> authorities =
-                Arrays.stream(claims.get(AUTHORITIES_KEY, String.class).split(","))
-                        .map(SimpleGrantedAuthority::new)
-                        .collect(Collectors.toList());
-
-        UserDetails principal = new User(claims.getSubject(), "", authorities);
-        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    public Authentication getAuthentication(String token, UserDetails userDetails) {
+        return new UsernamePasswordAuthenticationToken(userDetails, token, userDetails.getAuthorities());
     }
 
     public boolean validateToken(String token) {
@@ -87,6 +78,10 @@ public class JwtTokenProvider {
 
     public String getSubject(String token) {
         return parseClaims(token).getSubject();
+    }
+
+    public LocalDateTime getExpiration(String token) {
+        return LocalDateTime.ofInstant(parseClaims(token).getExpiration().toInstant(), ZoneId.systemDefault());
     }
 
     private Claims parseClaims(String token) {

--- a/src/main/java/com/aebong/store/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/aebong/store/common/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,100 @@
+package com.aebong.store.common.security.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private static final String AUTHORITIES_KEY = "auth";
+
+    private final SecretKey key;
+    private final long accessTokenValidityMs;
+    private final long refreshTokenValidityMs;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-validity-seconds}") long accessTokenValiditySeconds,
+            @Value("${jwt.refresh-token-validity-seconds}") long refreshTokenValiditySeconds) {
+        this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(
+                java.util.Base64.getEncoder().encodeToString(secret.getBytes())));
+        this.accessTokenValidityMs = accessTokenValiditySeconds * 1000;
+        this.refreshTokenValidityMs = refreshTokenValiditySeconds * 1000;
+    }
+
+    public String createAccessToken(Authentication authentication) {
+        return createToken(authentication, accessTokenValidityMs);
+    }
+
+    public String createRefreshToken(Authentication authentication) {
+        return createToken(authentication, refreshTokenValidityMs);
+    }
+
+    private String createToken(Authentication authentication, long validityMs) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = System.currentTimeMillis();
+        Date expiry = new Date(now + validityMs);
+
+        return Jwts.builder()
+                .subject(authentication.getName())
+                .claim(AUTHORITIES_KEY, authorities)
+                .issuedAt(new Date(now))
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY, String.class).split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("Invalid JWT token: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public String getSubject(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+}

--- a/src/main/java/com/aebong/store/common/security/userdetails/CustomUserDetails.java
+++ b/src/main/java/com/aebong/store/common/security/userdetails/CustomUserDetails.java
@@ -1,0 +1,53 @@
+package com.aebong.store.common.security.userdetails;
+
+import com.aebong.store.domain.entity.user.UserEntity;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final UserEntity userEntity;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + userEntity.getUserRole().name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return userEntity.getUserPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return userEntity.getUserAccount();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/aebong/store/common/security/userdetails/CustomUserDetailsService.java
+++ b/src/main/java/com/aebong/store/common/security/userdetails/CustomUserDetailsService.java
@@ -1,0 +1,23 @@
+package com.aebong.store.common.security.userdetails;
+
+import com.aebong.store.domain.entity.user.UserEntity;
+import com.aebong.store.domain.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String account) throws UsernameNotFoundException {
+        UserEntity userEntity = userRepository.findByUserAccount(account)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다. account=" + account));
+        return new CustomUserDetails(userEntity);
+    }
+}

--- a/src/main/java/com/aebong/store/config/SecurityConfig.java
+++ b/src/main/java/com/aebong/store/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.aebong.store.common.security.jwt.JwtAccessDeniedHandler;
 import com.aebong.store.common.security.jwt.JwtAuthenticationEntryPoint;
 import com.aebong.store.common.security.jwt.JwtAuthenticationFilter;
 import com.aebong.store.common.security.jwt.JwtTokenProvider;
+import com.aebong.store.common.security.userdetails.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,6 +31,7 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final CustomUserDetailsService customUserDetailsService;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -65,7 +67,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/categories/**").hasRole("ADMIN")
                         // 나머지는 인증 필요
                         .anyRequest().authenticated())
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, customUserDetailsService),
                         UsernamePasswordAuthenticationFilter.class)
                 // H2 console iframe 허용
                 .headers(headers -> headers.frameOptions(fo -> fo.sameOrigin()));

--- a/src/main/java/com/aebong/store/config/SecurityConfig.java
+++ b/src/main/java/com/aebong/store/config/SecurityConfig.java
@@ -1,0 +1,89 @@
+package com.aebong.store.config;
+
+import com.aebong.store.common.security.jwt.JwtAccessDeniedHandler;
+import com.aebong.store.common.security.jwt.JwtAuthenticationEntryPoint;
+import com.aebong.store.common.security.jwt.JwtAuthenticationFilter;
+import com.aebong.store.common.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler))
+                .authorizeHttpRequests(auth -> auth
+                        // 인증 없이 접근 가능한 경로
+                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers("/api/v1/users/register").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/products/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/categories/**").permitAll()
+                        // Thymeleaf 뷰, 정적 리소스
+                        .requestMatchers("/", "/h2-console/**", "/favicon.ico").permitAll()
+                        .requestMatchers("/css/**", "/js/**", "/images/**").permitAll()
+                        .requestMatchers("/view/**").permitAll()
+                        // ADMIN 전용 경로
+                        .requestMatchers(HttpMethod.POST, "/api/v1/products/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/products/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/products/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/v1/categories/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/categories/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/categories/**").hasRole("ADMIN")
+                        // 나머지는 인증 필요
+                        .anyRequest().authenticated())
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class)
+                // H2 console iframe 허용
+                .headers(headers -> headers.frameOptions(fo -> fo.sameOrigin()));
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOriginPatterns(List.of("*"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+}

--- a/src/main/java/com/aebong/store/controller/api/ProductController.java
+++ b/src/main/java/com/aebong/store/controller/api/ProductController.java
@@ -3,6 +3,7 @@ package com.aebong.store.controller.api;
 import com.aebong.store.common.api.ApiResponse;
 import com.aebong.store.service.product.ProductService;
 import com.aebong.store.service.product.dto.ProductGetInfo;
+import com.aebong.store.service.product.dto.ProductModifyRequest;
 import com.aebong.store.service.product.dto.ProductRegisterRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -40,12 +41,15 @@ public class ProductController {
     }
 
     @PatchMapping("/{productId}")
-    public ResponseEntity<ApiResponse<Void>> modifyProduct(@PathVariable Long productId) {
+    public ResponseEntity<ApiResponse<Void>> modifyProduct(@PathVariable Long productId,
+                                                           @RequestBody ProductModifyRequest modifyRequest) {
+        productService.modifyProduct(productId, modifyRequest);
         return new ResponseEntity<>(ApiResponse.success(), HttpStatus.OK);
     }
 
     @DeleteMapping("/{productId}")
     public ResponseEntity<ApiResponse<Void>> deleteProduct(@PathVariable Long productId) {
+        productService.deleteProduct(productId);
         return new ResponseEntity<>(ApiResponse.success(), HttpStatus.OK);
     }
 

--- a/src/main/java/com/aebong/store/controller/auth/AuthController.java
+++ b/src/main/java/com/aebong/store/controller/auth/AuthController.java
@@ -1,0 +1,37 @@
+package com.aebong.store.controller.auth;
+
+import com.aebong.store.common.api.ApiResponse;
+import com.aebong.store.common.security.userdetails.CustomUserDetails;
+import com.aebong.store.controller.req.AuthLoginRequest;
+import com.aebong.store.controller.req.AuthRefreshRequest;
+import com.aebong.store.service.auth.AuthService;
+import com.aebong.store.service.auth.dto.TokenResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<TokenResponse>> login(@RequestBody AuthLoginRequest request) {
+        return new ResponseEntity<>(ApiResponse.success(authService.login(request.getAccount(), request.getPassword())), HttpStatus.OK);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<TokenResponse>> refresh(@RequestBody AuthRefreshRequest request) {
+        return new ResponseEntity<>(ApiResponse.success(authService.refresh(request.getRefreshToken())), HttpStatus.OK);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        authService.logout(userDetails.getUsername());
+        return new ResponseEntity<>(ApiResponse.success(), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/aebong/store/controller/req/AddressRequest.java
+++ b/src/main/java/com/aebong/store/controller/req/AddressRequest.java
@@ -1,0 +1,19 @@
+package com.aebong.store.controller.req;
+
+import lombok.Data;
+
+@Data
+public class AddressRequest {
+
+    private String addressName;
+    private String firstName;
+    private String lastName;
+    private String mobileNumber;
+    private String telNumber;
+    private String address1;
+    private String address2;
+    private String zipcode;
+    private String deliveryMessage;
+    private Boolean isDefault;
+    private Boolean isAddressValid;
+}

--- a/src/main/java/com/aebong/store/controller/req/AuthLoginRequest.java
+++ b/src/main/java/com/aebong/store/controller/req/AuthLoginRequest.java
@@ -1,0 +1,10 @@
+package com.aebong.store.controller.req;
+
+import lombok.Data;
+
+@Data
+public class AuthLoginRequest {
+
+    private String account;
+    private String password;
+}

--- a/src/main/java/com/aebong/store/controller/req/AuthRefreshRequest.java
+++ b/src/main/java/com/aebong/store/controller/req/AuthRefreshRequest.java
@@ -1,0 +1,9 @@
+package com.aebong.store.controller.req;
+
+import lombok.Data;
+
+@Data
+public class AuthRefreshRequest {
+
+    private String refreshToken;
+}

--- a/src/main/java/com/aebong/store/controller/res/DeliveryAddressResponse.java
+++ b/src/main/java/com/aebong/store/controller/res/DeliveryAddressResponse.java
@@ -1,0 +1,42 @@
+package com.aebong.store.controller.res;
+
+import com.aebong.store.domain.entity.user.UserDeliveryAddressEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DeliveryAddressResponse {
+
+    private Long addressId;
+    private String userAccount;
+    private String addressName;
+    private String firstName;
+    private String lastName;
+    private String mobileNumber;
+    private String telNumber;
+    private String address1;
+    private String address2;
+    private String zipcode;
+    private String deliveryMessage;
+    private Boolean isDefault;
+    private Boolean isAddressValid;
+
+    public static DeliveryAddressResponse from(UserDeliveryAddressEntity entity) {
+        return DeliveryAddressResponse.builder()
+                .addressId(entity.getId())
+                .userAccount(entity.getUser().getUserAccount())
+                .addressName(entity.getAddressName())
+                .firstName(entity.getFirstName())
+                .lastName(entity.getLastName())
+                .mobileNumber(entity.getMobileNumber())
+                .telNumber(entity.getTelNumber())
+                .address1(entity.getAddress() == null ? null : entity.getAddress().getAddress1())
+                .address2(entity.getAddress() == null ? null : entity.getAddress().getAddress2())
+                .zipcode(entity.getAddress() == null ? null : entity.getAddress().getZipcode())
+                .deliveryMessage(entity.getDeliveryMessage())
+                .isDefault(entity.getIsDefault())
+                .isAddressValid(entity.getIsAddressValid())
+                .build();
+    }
+}

--- a/src/main/java/com/aebong/store/controller/user/DeliveryAddressController.java
+++ b/src/main/java/com/aebong/store/controller/user/DeliveryAddressController.java
@@ -1,0 +1,69 @@
+package com.aebong.store.controller.user;
+
+import com.aebong.store.common.api.ApiResponse;
+import com.aebong.store.common.security.userdetails.CustomUserDetails;
+import com.aebong.store.controller.req.AddressRequest;
+import com.aebong.store.controller.res.DeliveryAddressResponse;
+import com.aebong.store.service.user.DeliveryAddressService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/users/{userAccount}/addresses")
+@RequiredArgsConstructor
+public class DeliveryAddressController {
+
+    private final DeliveryAddressService deliveryAddressService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<DeliveryAddressResponse>>> getAddresses(@PathVariable String userAccount,
+                                                                                   @AuthenticationPrincipal CustomUserDetails userDetails) {
+        validateAccount(userAccount, userDetails);
+        return new ResponseEntity<>(ApiResponse.success(deliveryAddressService.getAddresses(userAccount)), HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<DeliveryAddressResponse>> addAddress(@PathVariable String userAccount,
+                                                                           @RequestBody AddressRequest request,
+                                                                           @AuthenticationPrincipal CustomUserDetails userDetails) {
+        validateAccount(userAccount, userDetails);
+        return new ResponseEntity<>(ApiResponse.success(deliveryAddressService.addAddress(userAccount, request)), HttpStatus.OK);
+    }
+
+    @PatchMapping("/{addressId}")
+    public ResponseEntity<ApiResponse<DeliveryAddressResponse>> modifyAddress(@PathVariable String userAccount,
+                                                                              @PathVariable Long addressId,
+                                                                              @RequestBody AddressRequest request,
+                                                                              @AuthenticationPrincipal CustomUserDetails userDetails) {
+        validateAccount(userAccount, userDetails);
+        return new ResponseEntity<>(ApiResponse.success(deliveryAddressService.modifyAddress(userAccount, addressId, request)), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{addressId}")
+    public ResponseEntity<ApiResponse<Void>> deleteAddress(@PathVariable String userAccount,
+                                                           @PathVariable Long addressId,
+                                                           @AuthenticationPrincipal CustomUserDetails userDetails) {
+        validateAccount(userAccount, userDetails);
+        deliveryAddressService.deleteAddress(userAccount, addressId);
+        return new ResponseEntity<>(ApiResponse.success(), HttpStatus.OK);
+    }
+
+    @PatchMapping("/{addressId}/default")
+    public ResponseEntity<ApiResponse<DeliveryAddressResponse>> setDefaultAddress(@PathVariable String userAccount,
+                                                                                  @PathVariable Long addressId,
+                                                                                  @AuthenticationPrincipal CustomUserDetails userDetails) {
+        validateAccount(userAccount, userDetails);
+        return new ResponseEntity<>(ApiResponse.success(deliveryAddressService.setDefaultAddress(userAccount, addressId)), HttpStatus.OK);
+    }
+
+    private void validateAccount(String userAccount, CustomUserDetails userDetails) {
+        if (userDetails == null || !userAccount.equals(userDetails.getUsername())) {
+            throw new com.aebong.store.common.exception.ForbiddenException("본인 배송지만 접근할 수 있습니다.");
+        }
+    }
+}

--- a/src/main/java/com/aebong/store/domain/entity/product/ProductDetailEntity.java
+++ b/src/main/java/com/aebong/store/domain/entity/product/ProductDetailEntity.java
@@ -1,6 +1,7 @@
 package com.aebong.store.domain.entity.product;
 
 import com.aebong.store.domain.entity.AuditingEntity;
+import com.aebong.store.service.product.dto.ProductModifyRequest;
 import com.aebong.store.service.product.dto.ProductRegisterInfo;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -86,6 +87,15 @@ public class ProductDetailEntity extends AuditingEntity {
         this.detailDescription = detailDescription;
         this.manufacturerCountry = manufacturerCountry;
         this.releaseDatetime = releaseDatetime;
+    }
+
+    public void modify(ProductModifyRequest request) {
+        if (Objects.nonNull(request.getProductName())) this.productName = request.getProductName();
+        if (Objects.nonNull(request.getProductEnglishName())) this.productEnglishName = request.getProductEnglishName();
+        if (Objects.nonNull(request.getProductShortName())) this.productShortName = request.getProductShortName();
+        if (Objects.nonNull(request.getBasicDescription())) this.basicDescription = request.getBasicDescription();
+        if (Objects.nonNull(request.getDetailDescription())) this.detailDescription = request.getDetailDescription();
+        if (Objects.nonNull(request.getManufacturerCountry())) this.manufacturerCountry = request.getManufacturerCountry();
     }
 
     public static ProductDetailEntity create(ProductEntity product, ProductRegisterInfo registerInfo) {

--- a/src/main/java/com/aebong/store/domain/entity/product/ProductEntity.java
+++ b/src/main/java/com/aebong/store/domain/entity/product/ProductEntity.java
@@ -2,6 +2,7 @@ package com.aebong.store.domain.entity.product;
 
 import com.aebong.store.common.enums.product.ProductType;
 import com.aebong.store.domain.entity.AuditingEntity;
+import com.aebong.store.service.product.dto.ProductModifyRequest;
 import com.aebong.store.service.product.dto.ProductRegisterInfo;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -10,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -33,6 +35,18 @@ public class ProductEntity extends AuditingEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "product_type", nullable = false, length = 100)
     private ProductType productType;
+
+    @Comment("재고수량")
+    @Column(name = "stock", nullable = false)
+    private Integer stock = 0;
+
+    @Comment("삭제일시")
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
 
     @OneToMany(mappedBy = "product")
     private List<PriceEntity> prices = new ArrayList<>();
@@ -66,10 +80,12 @@ public class ProductEntity extends AuditingEntity {
     @Builder
     private ProductEntity(String productCode,
                           ProductType productType,
+                          Integer stock,
                           List<ProductCategoryEntity> productCategories,
                           List<ProductTagEntity> productTags) {
         this.productCode = productCode;
         this.productType = productType;
+        this.stock = Objects.isNull(stock) ? 0 : stock;
         this.productCategories = productCategories;
         this.productTags = productTags;
     }
@@ -80,6 +96,20 @@ public class ProductEntity extends AuditingEntity {
                 .productCode(registerInfo.getProductCode())
                 .productType(registerInfo.getProductType())
                 .build();
+    }
+
+    public void modify(ProductModifyRequest request) {
+        if (Objects.nonNull(request.getProductType())) {
+            this.productType = request.getProductType();
+        }
+        if (Objects.nonNull(request.getStock())) {
+            this.stock = request.getStock();
+        }
+    }
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+        setDelete();
     }
 
 }

--- a/src/main/java/com/aebong/store/domain/entity/user/RefreshTokenEntity.java
+++ b/src/main/java/com/aebong/store/domain/entity/user/RefreshTokenEntity.java
@@ -1,0 +1,57 @@
+package com.aebong.store.domain.entity.user;
+
+import com.aebong.store.common.util.BooleanToYnConverter;
+import com.aebong.store.domain.entity.AuditingEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "refresh_token",
+        uniqueConstraints = @UniqueConstraint(name = "uk_refresh_token_hash", columnNames = "token_hash")
+)
+@Entity
+public class RefreshTokenEntity extends AuditingEntity {
+
+    @Comment("리프레시 토큰 PK")
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_token_id", nullable = false)
+    private Long id;
+
+    @Comment("회원계정")
+    @Column(name = "user_account", nullable = false, length = 30)
+    private String userAccount;
+
+    @Comment("리프레시 토큰 해시")
+    @Column(name = "token_hash", nullable = false, length = 64)
+    private String tokenHash;
+
+    @Comment("만료일시")
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Comment("폐기여부")
+    @Convert(converter = BooleanToYnConverter.class)
+    @Column(name = "revoked_yn", nullable = false)
+    private Boolean isRevoked;
+
+    @Builder
+    private RefreshTokenEntity(String userAccount, String tokenHash, LocalDateTime expiresAt, Boolean isRevoked) {
+        this.userAccount = userAccount;
+        this.tokenHash = tokenHash;
+        this.expiresAt = expiresAt;
+        this.isRevoked = isRevoked == null ? Boolean.FALSE : isRevoked;
+    }
+
+    public void revoke() {
+        this.isRevoked = Boolean.TRUE;
+    }
+}

--- a/src/main/java/com/aebong/store/domain/entity/user/UserDeliveryAddressEntity.java
+++ b/src/main/java/com/aebong/store/domain/entity/user/UserDeliveryAddressEntity.java
@@ -93,4 +93,30 @@ public class UserDeliveryAddressEntity extends AuditingEntity {
         this.isAddressValid = isAddressValid;
     }
 
+    public void update(String addressName,
+                       String firstName,
+                       String lastName,
+                       String mobileNumber,
+                       String telNumber,
+                       Address address,
+                       String deliveryMessage,
+                       Boolean isAddressValid) {
+        this.addressName = addressName;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.mobileNumber = mobileNumber;
+        this.telNumber = telNumber;
+        this.address = address;
+        this.deliveryMessage = deliveryMessage;
+        this.isAddressValid = isAddressValid;
+    }
+
+    public void setDefaultAddress() {
+        this.isDefault = Boolean.TRUE;
+    }
+
+    public void unsetDefaultAddress() {
+        this.isDefault = Boolean.FALSE;
+    }
+
 }

--- a/src/main/java/com/aebong/store/domain/entity/user/UserEntity.java
+++ b/src/main/java/com/aebong/store/domain/entity/user/UserEntity.java
@@ -1,6 +1,7 @@
 package com.aebong.store.domain.entity.user;
 
 import com.aebong.store.common.enums.user.UserAccountType;
+import com.aebong.store.common.enums.user.UserRole;
 import com.aebong.store.common.enums.user.UserStatus;
 import com.aebong.store.common.enums.user.UserType;
 import com.aebong.store.common.util.BooleanToYnConverter;
@@ -52,6 +53,11 @@ public class UserEntity extends AuditingEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "user_status", nullable = false, length = 20)
     private UserStatus userStatus;
+
+    @Comment("회원권한")
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_role", nullable = false, length = 20)
+    private UserRole userRole;
 
     @Comment("비밀번호 초기화 필요 여부")
     @Convert(converter = BooleanToYnConverter.class)
@@ -119,6 +125,7 @@ public class UserEntity extends AuditingEntity {
                        UserAccountType userAccountType,
                        String userPassword,
                        UserStatus userStatus,
+                       UserRole userRole,
                        Boolean passwordInitYn,
                        int failPasswordCount,
                        LocalDateTime accountLockedDatetime,
@@ -132,6 +139,7 @@ public class UserEntity extends AuditingEntity {
         this.userAccountType = userAccountType;
         this.userPassword = userPassword;
         this.userStatus = userStatus;
+        this.userRole = Objects.isNull(userRole) ? UserRole.CUSTOMER : userRole;
         this.passwordInitYn = Objects.isNull(passwordInitYn) ? Boolean.FALSE : passwordInitYn;
         this.failPasswordCount = Objects.isNull(failPasswordCount) ? 0 : failPasswordCount;
         this.accountLockedDatetime = accountLockedDatetime;

--- a/src/main/java/com/aebong/store/domain/repository/user/RefreshTokenRepository.java
+++ b/src/main/java/com/aebong/store/domain/repository/user/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package com.aebong.store.domain.repository.user;
+
+import com.aebong.store.domain.entity.user.RefreshTokenEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, Long> {
+
+    Optional<RefreshTokenEntity> findByTokenHash(String tokenHash);
+
+    void deleteByUserAccount(String userAccount);
+}

--- a/src/main/java/com/aebong/store/domain/repository/user/UserDeliveryAddressRepository.java
+++ b/src/main/java/com/aebong/store/domain/repository/user/UserDeliveryAddressRepository.java
@@ -3,6 +3,15 @@ package com.aebong.store.domain.repository.user;
 import com.aebong.store.domain.entity.user.UserDeliveryAddressEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface UserDeliveryAddressRepository extends JpaRepository<UserDeliveryAddressEntity, Long> {
+
+    List<UserDeliveryAddressEntity> findAllByUser_UserAccountOrderByIdDesc(String userAccount);
+
+    Optional<UserDeliveryAddressEntity> findByIdAndUser_UserAccount(Long id, String userAccount);
+
+    Optional<UserDeliveryAddressEntity> findByUser_UserAccountAndIsDefaultTrue(String userAccount);
 
 }

--- a/src/main/java/com/aebong/store/service/auth/AuthService.java
+++ b/src/main/java/com/aebong/store/service/auth/AuthService.java
@@ -1,0 +1,116 @@
+package com.aebong.store.service.auth;
+
+import com.aebong.store.common.exception.ResourceNotFoundException;
+import com.aebong.store.common.exception.UnauthorizedException;
+import com.aebong.store.common.security.jwt.JwtTokenProvider;
+import com.aebong.store.common.security.userdetails.CustomUserDetails;
+import com.aebong.store.domain.entity.user.RefreshTokenEntity;
+import com.aebong.store.domain.entity.user.UserEntity;
+import com.aebong.store.domain.repository.user.RefreshTokenRepository;
+import com.aebong.store.domain.repository.user.UserRepository;
+import com.aebong.store.service.auth.dto.TokenResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.HexFormat;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public TokenResponse login(String account, String password) {
+        UserEntity userEntity = userRepository.findByUserAccount(account)
+                .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다. account=" + account));
+
+        if (!matchesPassword(password, userEntity.getUserPassword())) {
+            throw new UnauthorizedException("계정 또는 비밀번호가 올바르지 않습니다.");
+        }
+
+        CustomUserDetails userDetails = new CustomUserDetails(userEntity);
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+        String accessToken = jwtTokenProvider.createAccessToken(authentication);
+        String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
+
+        refreshTokenRepository.deleteByUserAccount(account);
+        refreshTokenRepository.save(RefreshTokenEntity.builder()
+                .userAccount(account)
+                .tokenHash(hashToken(refreshToken))
+                .expiresAt(jwtTokenProvider.getExpiration(refreshToken))
+                .isRevoked(Boolean.FALSE)
+                .build());
+
+        return TokenResponse.of(accessToken, refreshToken);
+    }
+
+    @Transactional(readOnly = true)
+    public TokenResponse refresh(String refreshToken) {
+        validateRefreshToken(refreshToken);
+
+        RefreshTokenEntity tokenEntity = refreshTokenRepository.findByTokenHash(hashToken(refreshToken))
+                .orElseThrow(() -> new UnauthorizedException("유효하지 않은 리프레시 토큰입니다."));
+
+        if (Boolean.TRUE.equals(tokenEntity.getIsRevoked()) || LocalDateTime.now().isAfter(tokenEntity.getExpiresAt())) {
+            throw new UnauthorizedException("만료되었거나 폐기된 리프레시 토큰입니다.");
+        }
+
+        UserEntity userEntity = userRepository.findByUserAccount(tokenEntity.getUserAccount())
+                .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다. account=" + tokenEntity.getUserAccount()));
+
+        CustomUserDetails userDetails = new CustomUserDetails(userEntity);
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+        return TokenResponse.accessTokenOnly(jwtTokenProvider.createAccessToken(authentication));
+    }
+
+    @Transactional
+    public void logout(String account) {
+        if (!StringUtils.hasText(account)) {
+            throw new UnauthorizedException("로그인 정보가 필요합니다.");
+        }
+        refreshTokenRepository.deleteByUserAccount(account);
+    }
+
+    private void validateRefreshToken(String refreshToken) {
+        if (!StringUtils.hasText(refreshToken) || !jwtTokenProvider.validateToken(refreshToken)) {
+            throw new UnauthorizedException("유효하지 않은 리프레시 토큰입니다.");
+        }
+    }
+
+    private boolean matchesPassword(String rawPassword, String savedPassword) {
+        if (!StringUtils.hasText(rawPassword) || !StringUtils.hasText(savedPassword)) {
+            return false;
+        }
+
+        if (savedPassword.startsWith("$2a$") || savedPassword.startsWith("$2b$") || savedPassword.startsWith("$2y$")) {
+            return passwordEncoder.matches(rawPassword, savedPassword);
+        }
+        return rawPassword.equals(savedPassword);
+    }
+
+    private String hashToken(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashed);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 해시 생성에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/aebong/store/service/auth/dto/TokenResponse.java
+++ b/src/main/java/com/aebong/store/service/auth/dto/TokenResponse.java
@@ -1,0 +1,28 @@
+package com.aebong.store.service.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenResponse {
+
+    private String accessToken;
+    private String refreshToken;
+    private String tokenType;
+
+    public static TokenResponse of(String accessToken, String refreshToken) {
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .tokenType("Bearer")
+                .build();
+    }
+
+    public static TokenResponse accessTokenOnly(String accessToken) {
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .tokenType("Bearer")
+                .build();
+    }
+}

--- a/src/main/java/com/aebong/store/service/product/ProductService.java
+++ b/src/main/java/com/aebong/store/service/product/ProductService.java
@@ -1,32 +1,21 @@
 package com.aebong.store.service.product;
 
 import com.aebong.store.service.product.dto.ProductGetInfo;
+import com.aebong.store.service.product.dto.ProductModifyRequest;
 import com.aebong.store.service.product.dto.ProductRegisterRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
-
 public interface ProductService {
 
-    /**
-     * 상품 등록
-     * @param registerRequest 상품 등록 정보(api 통해 request 로 부터 받아올 매개변수)
-     */
     void registerProduct(ProductRegisterRequest registerRequest);
 
-    /**
-     * 상품 정보 조회
-     * @param productId
-     * @return ProductGetInfo
-     */
     ProductGetInfo getProduct(Long productId);
 
-    /**
-     * 상품 정보 목록 조회
-     * @param pageable
-     * @return Page<ProductGetInfo>
-     */
     Page<ProductGetInfo> getProducts(Pageable pageable);
+
+    void modifyProduct(Long productId, ProductModifyRequest modifyRequest);
+
+    void deleteProduct(Long productId);
 
 }

--- a/src/main/java/com/aebong/store/service/product/ProductServiceImpl.java
+++ b/src/main/java/com/aebong/store/service/product/ProductServiceImpl.java
@@ -11,6 +11,7 @@ import com.aebong.store.domain.repository.product.PriceRepository;
 import com.aebong.store.domain.repository.product.ProductDetailRepository;
 import com.aebong.store.domain.repository.product.ProductRepository;
 import com.aebong.store.service.product.dto.ProductGetInfo;
+import com.aebong.store.service.product.dto.ProductModifyRequest;
 import com.aebong.store.service.product.dto.ProductRegisterInfo;
 import com.aebong.store.service.product.dto.ProductRegisterRequest;
 import lombok.RequiredArgsConstructor;
@@ -103,6 +104,38 @@ public class ProductServiceImpl implements ProductService {
     @Override
     public Page<ProductGetInfo> getProducts(Pageable pageable) {
         return productRepository.findAllProducts(pageable);
+    }
+
+    @Transactional
+    @Override
+    public void modifyProduct(Long productId, ProductModifyRequest modifyRequest) {
+        if (Objects.isNull(productId)) {
+            throw new ProductApplicationException(CustomErrorType.BAD_REQUEST, "productId must not be null");
+        }
+        if (Objects.isNull(modifyRequest)) {
+            throw new ProductApplicationException(CustomErrorType.BAD_REQUEST, "modifyRequest must not be null");
+        }
+
+        ProductEntity product = productRepository.findByProductId(productId).orElseThrow(
+                () -> new ProductApplicationException(CustomErrorType.NOT_FOUND_PRODUCT, CustomErrorType.NOT_FOUND_PRODUCT.getMessage()));
+
+        product.modify(modifyRequest);
+        if (product.getProductDetail() != null) {
+            product.getProductDetail().modify(modifyRequest);
+        }
+    }
+
+    @Transactional
+    @Override
+    public void deleteProduct(Long productId) {
+        if (Objects.isNull(productId)) {
+            throw new ProductApplicationException(CustomErrorType.BAD_REQUEST, "productId must not be null");
+        }
+
+        ProductEntity product = productRepository.findByProductId(productId).orElseThrow(
+                () -> new ProductApplicationException(CustomErrorType.NOT_FOUND_PRODUCT, CustomErrorType.NOT_FOUND_PRODUCT.getMessage()));
+
+        product.softDelete();
     }
 
     private boolean validateProductCodeIsExists(String productCode) {

--- a/src/main/java/com/aebong/store/service/product/dto/ProductModifyRequest.java
+++ b/src/main/java/com/aebong/store/service/product/dto/ProductModifyRequest.java
@@ -1,0 +1,20 @@
+package com.aebong.store.service.product.dto;
+
+import com.aebong.store.common.enums.product.ProductType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProductModifyRequest {
+
+    private ProductType productType;
+    private Integer stock;
+    private String productName;
+    private String productEnglishName;
+    private String productShortName;
+    private String basicDescription;
+    private String detailDescription;
+    private String manufacturerCountry;
+
+}

--- a/src/main/java/com/aebong/store/service/user/DeliveryAddressService.java
+++ b/src/main/java/com/aebong/store/service/user/DeliveryAddressService.java
@@ -1,0 +1,121 @@
+package com.aebong.store.service.user;
+
+import com.aebong.store.common.exception.ForbiddenException;
+import com.aebong.store.common.exception.ResourceNotFoundException;
+import com.aebong.store.controller.req.AddressRequest;
+import com.aebong.store.controller.res.DeliveryAddressResponse;
+import com.aebong.store.domain.entity.Address;
+import com.aebong.store.domain.entity.user.UserDeliveryAddressEntity;
+import com.aebong.store.domain.entity.user.UserEntity;
+import com.aebong.store.domain.repository.user.UserDeliveryAddressRepository;
+import com.aebong.store.domain.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryAddressService {
+
+    private final UserRepository userRepository;
+    private final UserDeliveryAddressRepository userDeliveryAddressRepository;
+
+    @Transactional(readOnly = true)
+    public List<DeliveryAddressResponse> getAddresses(String account) {
+        validateUser(account);
+        return userDeliveryAddressRepository.findAllByUser_UserAccountOrderByIdDesc(account).stream()
+                .map(DeliveryAddressResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public DeliveryAddressResponse addAddress(String account, AddressRequest request) {
+        UserEntity userEntity = validateUser(account);
+
+        boolean makeDefault = Boolean.TRUE.equals(request.getIsDefault())
+                || userDeliveryAddressRepository.findAllByUser_UserAccountOrderByIdDesc(account).isEmpty();
+
+        if (makeDefault) {
+            userDeliveryAddressRepository.findByUser_UserAccountAndIsDefaultTrue(account)
+                    .ifPresent(UserDeliveryAddressEntity::unsetDefaultAddress);
+        }
+
+        UserDeliveryAddressEntity entity = UserDeliveryAddressEntity.builder()
+                .user(userEntity)
+                .addressName(request.getAddressName())
+                .firstName(request.getFirstName())
+                .lastName(request.getLastName())
+                .mobileNumber(request.getMobileNumber())
+                .telNumber(request.getTelNumber())
+                .address(toAddress(request))
+                .deliveryMessage(request.getDeliveryMessage())
+                .isDefault(makeDefault)
+                .isAddressValid(request.getIsAddressValid() == null ? Boolean.TRUE : request.getIsAddressValid())
+                .build();
+
+        return DeliveryAddressResponse.from(userDeliveryAddressRepository.save(entity));
+    }
+
+    @Transactional
+    public DeliveryAddressResponse modifyAddress(String account, Long addressId, AddressRequest request) {
+        UserDeliveryAddressEntity entity = getOwnedAddress(account, addressId);
+
+        entity.update(
+                request.getAddressName(),
+                request.getFirstName(),
+                request.getLastName(),
+                request.getMobileNumber(),
+                request.getTelNumber(),
+                toAddress(request),
+                request.getDeliveryMessage(),
+                request.getIsAddressValid() == null ? entity.getIsAddressValid() : request.getIsAddressValid()
+        );
+
+        return DeliveryAddressResponse.from(entity);
+    }
+
+    @Transactional
+    public void deleteAddress(String account, Long addressId) {
+        UserDeliveryAddressEntity entity = getOwnedAddress(account, addressId);
+        userDeliveryAddressRepository.delete(entity);
+    }
+
+    @Transactional
+    public DeliveryAddressResponse setDefaultAddress(String account, Long addressId) {
+        UserDeliveryAddressEntity entity = getOwnedAddress(account, addressId);
+
+        userDeliveryAddressRepository.findByUser_UserAccountAndIsDefaultTrue(account)
+                .filter(defaultAddress -> !Objects.equals(defaultAddress.getId(), addressId))
+                .ifPresent(UserDeliveryAddressEntity::unsetDefaultAddress);
+
+        entity.setDefaultAddress();
+        return DeliveryAddressResponse.from(entity);
+    }
+
+    private UserEntity validateUser(String account) {
+        return userRepository.findByUserAccount(account)
+                .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다. account=" + account));
+    }
+
+    private UserDeliveryAddressEntity getOwnedAddress(String account, Long addressId) {
+        UserDeliveryAddressEntity entity = userDeliveryAddressRepository.findById(addressId)
+                .orElseThrow(() -> new ResourceNotFoundException("배송지를 찾을 수 없습니다. addressId=" + addressId));
+
+        if (!entity.getUser().getUserAccount().equals(account)) {
+            throw new ForbiddenException("해당 배송지에 접근할 수 없습니다.");
+        }
+
+        return entity;
+    }
+
+    private Address toAddress(AddressRequest request) {
+        return Address.builder()
+                .address1(request.getAddress1())
+                .address2(request.getAddress2())
+                .zipcode(request.getZipcode())
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,11 @@ spring:
   main:
     banner-mode: console
 
+jwt:
+  secret: aebong-store-jwt-secret-key-must-be-at-least-256-bits-long-for-hs256
+  access-token-validity-seconds: 1800
+  refresh-token-validity-seconds: 604800
+
 ---
 
 spring.config.activate.on-profile: test

--- a/src/test/java/com/aebong/store/controller/ProductControllerTest.java
+++ b/src/test/java/com/aebong/store/controller/ProductControllerTest.java
@@ -17,6 +17,7 @@ import com.aebong.store.service.product.dto.ProductRegisterRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -49,6 +50,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureRestDocs(outputDir = "build/generated-snippets")
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(ProductController.class)
 class ProductControllerTest {
 

--- a/src/test/java/com/aebong/store/controller/UserControllerTest.java
+++ b/src/test/java/com/aebong/store/controller/UserControllerTest.java
@@ -17,6 +17,7 @@ import com.aebong.store.service.user.dto.UserGetInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -40,6 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @AutoConfigureRestDocs(outputDir = "build/generated-snippets")
+@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(UserController.class)
 class UserControllerTest {
 

--- a/src/test/java/com/aebong/store/service/auth/AuthServiceTest.java
+++ b/src/test/java/com/aebong/store/service/auth/AuthServiceTest.java
@@ -1,0 +1,138 @@
+package com.aebong.store.service.auth;
+
+import com.aebong.store.common.enums.user.UserAccountType;
+import com.aebong.store.common.enums.user.UserRole;
+import com.aebong.store.common.enums.user.UserStatus;
+import com.aebong.store.common.enums.user.UserType;
+import com.aebong.store.common.exception.ResourceNotFoundException;
+import com.aebong.store.common.exception.UnauthorizedException;
+import com.aebong.store.common.security.jwt.JwtTokenProvider;
+import com.aebong.store.domain.entity.user.RefreshTokenEntity;
+import com.aebong.store.domain.entity.user.UserEntity;
+import com.aebong.store.domain.repository.user.RefreshTokenRepository;
+import com.aebong.store.domain.repository.user.UserRepository;
+import com.aebong.store.service.auth.dto.TokenResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private AuthService authService;
+
+    private UserEntity userEntity;
+
+    @BeforeEach
+    void setUp() {
+        userEntity = UserEntity.builder()
+                .userType(UserType.REGULAR_MEMBER)
+                .userAccount("tester")
+                .userAccountType(UserAccountType.EMAIL)
+                .userPassword("plain-password")
+                .userStatus(UserStatus.ACTIVATED)
+                .userRole(UserRole.CUSTOMER)
+                .build();
+    }
+
+    @Test
+    void 로그인_성공() {
+        when(userRepository.findByUserAccount("tester")).thenReturn(Optional.of(userEntity));
+        when(jwtTokenProvider.createAccessToken(any())).thenReturn("access-token");
+        when(jwtTokenProvider.createRefreshToken(any())).thenReturn("refresh-token");
+        when(jwtTokenProvider.getExpiration("refresh-token")).thenReturn(LocalDateTime.now().plusDays(7));
+
+        TokenResponse response = authService.login("tester", "plain-password");
+
+        ArgumentCaptor<RefreshTokenEntity> refreshTokenCaptor = ArgumentCaptor.forClass(RefreshTokenEntity.class);
+        verify(refreshTokenRepository).deleteByUserAccount("tester");
+        verify(refreshTokenRepository).save(refreshTokenCaptor.capture());
+
+        assertThat(response.getAccessToken()).isEqualTo("access-token");
+        assertThat(response.getRefreshToken()).isEqualTo("refresh-token");
+        assertThat(response.getTokenType()).isEqualTo("Bearer");
+        assertThat(refreshTokenCaptor.getValue().getUserAccount()).isEqualTo("tester");
+        assertThat(refreshTokenCaptor.getValue().getTokenHash()).hasSize(64);
+    }
+
+    @Test
+    void 로그인_실패_존재하지_않는_계정() {
+        when(userRepository.findByUserAccount("missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.login("missing", "password"))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("사용자를 찾을 수 없습니다.");
+    }
+
+    @Test
+    void 로그인_실패_비밀번호_불일치() {
+        UserEntity encodedUser = UserEntity.builder()
+                .userType(UserType.REGULAR_MEMBER)
+                .userAccount("tester")
+                .userAccountType(UserAccountType.EMAIL)
+                .userPassword("$2a$encoded")
+                .userStatus(UserStatus.ACTIVATED)
+                .userRole(UserRole.CUSTOMER)
+                .build();
+
+        when(userRepository.findByUserAccount("tester")).thenReturn(Optional.of(encodedUser));
+        when(passwordEncoder.matches("wrong-password", "$2a$encoded")).thenReturn(false);
+
+        assertThatThrownBy(() -> authService.login("tester", "wrong-password"))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("계정 또는 비밀번호가 올바르지 않습니다.");
+    }
+
+    @Test
+    void 토큰_재발급_성공() {
+        RefreshTokenEntity refreshTokenEntity = RefreshTokenEntity.builder()
+                .userAccount("tester")
+                .tokenHash("hashed-token")
+                .expiresAt(LocalDateTime.now().plusDays(1))
+                .isRevoked(Boolean.FALSE)
+                .build();
+
+        when(jwtTokenProvider.validateToken("refresh-token")).thenReturn(true);
+        when(refreshTokenRepository.findByTokenHash(anyString())).thenReturn(Optional.of(refreshTokenEntity));
+        when(userRepository.findByUserAccount("tester")).thenReturn(Optional.of(userEntity));
+        when(jwtTokenProvider.createAccessToken(any())).thenReturn("new-access-token");
+
+        TokenResponse response = authService.refresh("refresh-token");
+
+        assertThat(response.getAccessToken()).isEqualTo("new-access-token");
+        assertThat(response.getRefreshToken()).isNull();
+        assertThat(response.getTokenType()).isEqualTo("Bearer");
+    }
+
+    @Test
+    void 로그아웃_성공() {
+        authService.logout("tester");
+
+        verify(refreshTokenRepository).deleteByUserAccount("tester");
+        verifyNoMoreInteractions(refreshTokenRepository);
+    }
+}

--- a/src/test/java/com/aebong/store/service/user/DeliveryAddressServiceTest.java
+++ b/src/test/java/com/aebong/store/service/user/DeliveryAddressServiceTest.java
@@ -1,0 +1,183 @@
+package com.aebong.store.service.user;
+
+import com.aebong.store.common.enums.user.UserAccountType;
+import com.aebong.store.common.enums.user.UserRole;
+import com.aebong.store.common.enums.user.UserStatus;
+import com.aebong.store.common.enums.user.UserType;
+import com.aebong.store.common.exception.ForbiddenException;
+import com.aebong.store.controller.req.AddressRequest;
+import com.aebong.store.controller.res.DeliveryAddressResponse;
+import com.aebong.store.domain.entity.Address;
+import com.aebong.store.domain.entity.user.UserDeliveryAddressEntity;
+import com.aebong.store.domain.entity.user.UserEntity;
+import com.aebong.store.domain.repository.user.UserDeliveryAddressRepository;
+import com.aebong.store.domain.repository.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DeliveryAddressServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private UserDeliveryAddressRepository userDeliveryAddressRepository;
+
+    @InjectMocks
+    private DeliveryAddressService deliveryAddressService;
+
+    private UserEntity userEntity;
+    private UserDeliveryAddressEntity addressEntity;
+
+    @BeforeEach
+    void setUp() {
+        userEntity = UserEntity.builder()
+                .userType(UserType.REGULAR_MEMBER)
+                .userAccount("tester")
+                .userAccountType(UserAccountType.EMAIL)
+                .userPassword("password")
+                .userStatus(UserStatus.ACTIVATED)
+                .userRole(UserRole.CUSTOMER)
+                .build();
+
+        addressEntity = UserDeliveryAddressEntity.builder()
+                .user(userEntity)
+                .addressName("집")
+                .firstName("길동")
+                .lastName("홍")
+                .mobileNumber("01012345678")
+                .telNumber("0212345678")
+                .address(Address.builder().address1("서울시").address2("101동").zipcode("12345").build())
+                .deliveryMessage("문 앞")
+                .isDefault(Boolean.TRUE)
+                .isAddressValid(Boolean.TRUE)
+                .build();
+    }
+
+    @Test
+    void 배송지목록_조회_성공() {
+        when(userRepository.findByUserAccount("tester")).thenReturn(Optional.of(userEntity));
+        when(userDeliveryAddressRepository.findAllByUser_UserAccountOrderByIdDesc("tester"))
+                .thenReturn(List.of(addressEntity));
+
+        List<DeliveryAddressResponse> responses = deliveryAddressService.getAddresses("tester");
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).getAddressName()).isEqualTo("집");
+    }
+
+    @Test
+    void 배송지_추가_성공() {
+        AddressRequest request = createAddressRequest();
+
+        when(userRepository.findByUserAccount("tester")).thenReturn(Optional.of(userEntity));
+        when(userDeliveryAddressRepository.save(any(UserDeliveryAddressEntity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        DeliveryAddressResponse response = deliveryAddressService.addAddress("tester", request);
+
+        verify(userDeliveryAddressRepository).findByUser_UserAccountAndIsDefaultTrue("tester");
+        assertThat(response.getAddressName()).isEqualTo("회사");
+        assertThat(response.getIsDefault()).isTrue();
+    }
+
+    @Test
+    void 배송지_수정_성공() {
+        AddressRequest request = createAddressRequest();
+        request.setAddressName("수정된 배송지");
+
+        when(userDeliveryAddressRepository.findById(1L)).thenReturn(Optional.of(addressEntity));
+
+        DeliveryAddressResponse response = deliveryAddressService.modifyAddress("tester", 1L, request);
+
+        assertThat(response.getAddressName()).isEqualTo("수정된 배송지");
+        assertThat(addressEntity.getAddressName()).isEqualTo("수정된 배송지");
+    }
+
+    @Test
+    void 배송지_삭제_성공() {
+        when(userDeliveryAddressRepository.findById(1L)).thenReturn(Optional.of(addressEntity));
+
+        deliveryAddressService.deleteAddress("tester", 1L);
+
+        verify(userDeliveryAddressRepository).delete(addressEntity);
+    }
+
+    @Test
+    void 기본배송지_설정_성공() {
+        UserDeliveryAddressEntity oldDefault = UserDeliveryAddressEntity.builder()
+                .user(userEntity)
+                .addressName("기존 기본")
+                .firstName("길동")
+                .lastName("홍")
+                .mobileNumber("01012345678")
+                .address(Address.builder().address1("서울시").zipcode("12345").build())
+                .deliveryMessage("경비실")
+                .isDefault(Boolean.TRUE)
+                .isAddressValid(Boolean.TRUE)
+                .build();
+
+        when(userDeliveryAddressRepository.findById(1L)).thenReturn(Optional.of(addressEntity));
+        when(userDeliveryAddressRepository.findByUser_UserAccountAndIsDefaultTrue("tester"))
+                .thenReturn(Optional.of(oldDefault));
+
+        DeliveryAddressResponse response = deliveryAddressService.setDefaultAddress("tester", 1L);
+
+        assertThat(response.getIsDefault()).isTrue();
+        assertThat(oldDefault.getIsDefault()).isFalse();
+    }
+
+    @Test
+    void 배송지_수정_실패_타인배송지() {
+        UserEntity anotherUser = UserEntity.builder()
+                .userType(UserType.REGULAR_MEMBER)
+                .userAccount("other")
+                .userAccountType(UserAccountType.EMAIL)
+                .userPassword("password")
+                .userStatus(UserStatus.ACTIVATED)
+                .userRole(UserRole.CUSTOMER)
+                .build();
+
+        UserDeliveryAddressEntity anotherAddress = UserDeliveryAddressEntity.builder()
+                .user(anotherUser)
+                .addressName("타인 주소")
+                .address(Address.builder().address1("부산시").zipcode("54321").build())
+                .isDefault(Boolean.FALSE)
+                .isAddressValid(Boolean.TRUE)
+                .build();
+
+        when(userDeliveryAddressRepository.findById(99L)).thenReturn(Optional.of(anotherAddress));
+
+        assertThatThrownBy(() -> deliveryAddressService.modifyAddress("tester", 99L, createAddressRequest()))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("해당 배송지에 접근할 수 없습니다.");
+    }
+
+    private AddressRequest createAddressRequest() {
+        AddressRequest request = new AddressRequest();
+        request.setAddressName("회사");
+        request.setFirstName("길동");
+        request.setLastName("홍");
+        request.setMobileNumber("01099998888");
+        request.setTelNumber("0211112222");
+        request.setAddress1("판교로");
+        request.setAddress2("100");
+        request.setZipcode("13487");
+        request.setDeliveryMessage("보안실");
+        request.setIsDefault(Boolean.TRUE);
+        request.setIsAddressValid(Boolean.TRUE);
+        return request;
+    }
+}


### PR DESCRIPTION
## 개요
AEBONG STORE MALL Rebuilding — Phase 1 완료 PR

Backend_Developer_Agent_1, Backend_Developer_Agent_2의 작업을 통합한 브랜치입니다.
(`agent/backend-developer-agent-1/250f4ecf` 포함)

---

## 구현 내용

### [Backend_Developer_Agent_1] Spring Security + JWT 인프라 (커밋: `1c04919`)
- `build.gradle`: spring-security, jjwt 0.12.6, webflux, security-test 의존성 추가
- `SecurityConfig`: Stateless, CSRF disable, ADMIN/CUSTOMER 경로별 접근 제어
- `JwtTokenProvider`: AT/RT 생성·검증 (JJWT 0.12.x)
- `JwtAuthenticationFilter`, `JwtAuthenticationEntryPoint` (401), `JwtAccessDeniedHandler` (403)
- `UserRole` enum (ADMIN, CUSTOMER), `UserEntity.userRole` 필드 추가
- `ProductEntity`: stock, version(@Version), deletedAt 추가
- 상품 수정(PATCH), 소프트 삭제(DELETE) API — Closes #38, Closes #39

### [Backend_Developer_Agent_2] Auth API + 배송지 API (커밋: `b2cc486`)
- `CustomUserDetails`, `CustomUserDetailsService`
- `RefreshTokenEntity`, `RefreshTokenRepository` (SHA-256 hash 저장)
- `AuthService`, `AuthController`
  - POST `/api/v1/auth/login`
  - POST `/api/v1/auth/refresh`
  - POST `/api/v1/auth/logout`
- `UnauthorizedException`, `ForbiddenException`, `ResourceNotFoundException`
- `GlobalExceptionHandler` Security 예외 핸들러 추가
- `DeliveryAddressService`, `DeliveryAddressController`
  - GET/POST/PATCH/DELETE `/api/v1/users/{userAccount}/addresses`
  - PATCH `/api/v1/users/{userAccount}/addresses/{addressId}/default`
- 테스트: `AuthServiceTest`, `DeliveryAddressServiceTest`

---

## 관련 이슈
- Closes #40
- Closes #41
- Closes #42
- Multica AEB-4 (done)